### PR TITLE
fix: handle missing string

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -308,8 +308,15 @@ impl<'a, R: Read> DataReader<'a, R> {
                 }
             }
             _ if bit_width % 8 == 0 => {
-                let Ok(s) = String::from_utf8(self.reader.read_to_vec((bit_width / 8) as usize)?)
-                else {
+                let vec = self.reader.read_to_vec((bit_width / 8) as usize)?;
+                if vec.iter().all(|it| *it == 0xff) {
+                    return Ok(DataEvent::Data {
+                        idx,
+                        xy: b.xy,
+                        value: Value::Missing,
+                    });
+                }
+                let Ok(s) = String::from_utf8(vec) else {
                     return Err(Error::Fatal(format!(
                         "Failed to parse character string with bit width {bit_width}",
                     )));


### PR DESCRIPTION
<!-- Close or Related Issues -->

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- Emits missing strings as `Value::Missing` instead of failing to parse
  > Missing values shall be expressed by all bits set to 1 within the data width of the element. This
shall apply to all Table B elements, including elements defined as CCITT IA5, code tables and
flag tables, with the exception of data description operator qualifiers in Class 31.
  
  We now check if the data of a string has all bits set to 1. If that's the case, we return a missing value.


### Notes
<!-- If manual testing is required, please describe the procedure. -->

The test file I have requires #7 as well.
