### PR TITLE
feat: add method to get the underlying reader back

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -62,6 +62,11 @@ impl<'a, R: Read> DataReader<'a, R> {
             width_offset: 0,
         })
     }
+
+    /// Unwrap the underlying reader passed in [new][Self::new].
+    pub fn into_reader(self) -> R {
+        self.reader.into_reader()
+    }
 }
 
 struct StackEntry<'a> {


### PR DESCRIPTION
### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

After reading the data section, I want to get back the original reader I passed in.
To achieve this, this PR exposes the `into_reader` from `BitReader`.

